### PR TITLE
fix empty namespace issue

### DIFF
--- a/frontend/components/Workloads/WorkloadsList.vue
+++ b/frontend/components/Workloads/WorkloadsList.vue
@@ -148,6 +148,15 @@ export default class WorkloadsList extends Vue {
   -o-transform: translateY(40%);
 }
 
+/* Hack to replace empty table text */
+.vgt-text-disabled {
+  visibility: hidden;
+}
+.vgt-text-disabled:after {
+  content:'No workloads found in namespace.'; 
+  visibility: visible;
+}
+
 .workloads-list {
   height: calc(100% - 110px);
   min-height: 250px;

--- a/frontend/store/workloads/transformers.ts
+++ b/frontend/store/workloads/transformers.ts
@@ -15,6 +15,10 @@ function parseCurrentTag(currentTag: string): string {
 }
 
 export const workloadsTransformer = (workloads: any[]) => {
+    if (!workloads) {
+        return new Array();
+    }
+
     return workloads.reduce((accWorkloads: any, workload: any) => {
         if (!workload.Containers) {
             return accWorkloads;


### PR DESCRIPTION
Fix the issue of namespaces with no workloads causing the app to display an alert saying there was an error pulling workloads info.

The fix includes returning an empty array instead of just `null` to prevent the error, and "hacking" the `vue-good-table` plugin default empty table string ("No data for table") with another string using pure CSS.